### PR TITLE
Check if utility is installed, add support for npm, gemrc

### DIFF
--- a/proxy.sh
+++ b/proxy.sh
@@ -1,10 +1,32 @@
 #! /bin/sh
+check_install() {
+  output="$($1 --version)"
+  output_size=${#output}
+
+  if [ $output_size -eq 0 ]; then
+    echo '0'
+  else
+    echo '1'
+  fi
+}
 
 if [ -z "$1" ] || [ $1 != 'kgp' ] ; then
   unset http_proxy
   unset https_proxy
-  git config --unset http.proxy
-  git config --unset https.proxy
+
+  git_installed=$(check_install git)
+  if [ $git_installed -ne 0 ]; then
+    git config --unset http.proxy
+    git config --unset https.proxy
+  fi
+
+  npm_installed=$(check_install npm)
+  if [ $npm_installed -ne 0 ]; then
+    npm config delete proxy
+    npm config delete https-proxy
+  fi
+
+  export HTTP_PROXY=''
 
   mv ~/.ssh/config ~/.ssh/config.backup
   cp ~/.ssh/config.home ~/.ssh/config
@@ -15,8 +37,19 @@ else
 
   export http_proxy=$proxy
   export https_proxy=$proxy
-  git config --global https.proxy $proxy
-  git config --global http.proxy $proxy
+  git_installed=$(check_install git)
+  if [ $git_installed -ne 0 ]; then
+    git config --global https.proxy $proxy
+    git config --global http.proxy $proxy
+  fi
+
+  npm_installed=$(check_install npm)
+  if [ $npm_installed -ne 0 ]; then
+    npm config set proxy $proxy
+    npm config set https-proxy $proxy
+  fi
+  
+  export HTTP_PROXY=$proxy
 
   mv ~/.ssh/config ~/.ssh/config.backup
   cp ~/.ssh/config.kgp ~/.ssh/config


### PR DESCRIPTION
Relevant issue: #1 

Added a function to check if git / npm installed, so that can be extended to any  number of services.

~/.gemrc looks only at $HTTP_PROXY as per this [guide](http://guides.rubygems.org/command-reference/#gem-environment).
```
If you are behind a proxy server, RubyGems uses the HTTP_PROXY, HTTP_PROXY_USER and
 HTTP_PROXY_PASS environment variables to discover the proxy server.
```