### PR TITLE
Add proxy.fish, add global flag while unsetting git proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,19 @@ A proxy configuration file that solves the purpose of switching the proxies whil
 
 2. No need to clone the entire repository. Just get the `proxy.sh` file by typing this in your terminal -
 
-```console
+ ```console
 $ curl -o ~/.proxyrc https://raw.githubusercontent.com/athityakumar/proxyrc/master/proxy.sh
 ```
 
-3. Add this to your shell configuration file (`~/.bashrc`, `.zshrc` or `.fishrc`) -
+3. Add this to your shell configuration file (`~/.bashrc`, `.zshrc`) -
 
-```sh
+ ```sh
 proxy() { sh ~/.proxyrc $1; }
+```
+
+ If you use fish, you can get the function `proxy.fish` file by a simple curl command:
+ ```console
+$ curl -o ~/.config/fish/functions/proxy.fish https://raw.githubusercontent.com/athityakumar/proxyrc/master/proxy.fish
 ```
 
 ### Usage

--- a/proxy.fish
+++ b/proxy.fish
@@ -1,0 +1,4 @@
+function proxy -d 'switch proxies between KGP and home'
+    # posible arguments: kgp, home, no argument
+    sh ~/.proxyrc $argv
+end

--- a/proxy.sh
+++ b/proxy.sh
@@ -16,8 +16,8 @@ if [ -z "$1" ] || [ $1 != 'kgp' ] ; then
 
   git_installed=$(check_install git)
   if [ $git_installed -ne 0 ]; then
-    git config --unset http.proxy
-    git config --unset https.proxy
+    git config --global --unset http.proxy
+    git config --global --unset https.proxy
   fi
 
   npm_installed=$(check_install npm)


### PR DESCRIPTION
Closes issue #2 

Also added global flag for unset git proxy, because without `--global`, command does not work in non-git directories.